### PR TITLE
Add BreakdownQuoteCard component and update quotes

### DIFF
--- a/src/builder-registry.ts
+++ b/src/builder-registry.ts
@@ -1,413 +1,472 @@
-import { Builder } from '@builder.io/react';
+import { Builder } from "@builder.io/react";
 import {
   Badge,
   Button,
   Card,
   Input,
   Modal,
-} from './components/tuxedo';
-import HeroSection from './components/HeroSection';
-import NewsLetterCTA from './components/NewsLetterCTA';
-import FeatureCard from './components/FeatureCard';
-import FeaturesSection from './components/FeaturesSection';
-import WelcomeBanner from './components/WelcomeBanner';
+  BreakdownQuoteCard,
+} from "./components/tuxedo";
+import HeroSection from "./components/HeroSection";
+import NewsLetterCTA from "./components/NewsLetterCTA";
+import FeatureCard from "./components/FeatureCard";
+import FeaturesSection from "./components/FeaturesSection";
+import WelcomeBanner from "./components/WelcomeBanner";
 
 // Register all Tuxedo components with Builder.io
 Builder.registerComponent(Badge, {
-  name: 'Tuxedo Badge',
+  name: "Tuxedo Badge",
   inputs: [
     {
-      name: 'variant',
-      type: 'enum',
-      enum: ['primary', 'secondary', 'success', 'warning', 'danger', 'info'],
-      defaultValue: 'primary',
+      name: "variant",
+      type: "enum",
+      enum: ["primary", "secondary", "success", "warning", "danger", "info"],
+      defaultValue: "primary",
     },
     {
-      name: 'size',
-      type: 'enum',
-      enum: ['small', 'medium', 'large'],
-      defaultValue: 'medium',
+      name: "size",
+      type: "enum",
+      enum: ["small", "medium", "large"],
+      defaultValue: "medium",
     },
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Badge',
+      name: "children",
+      type: "string",
+      defaultValue: "Badge",
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
   ],
 });
 
 Builder.registerComponent(Button, {
-  name: 'Tuxedo Button',
+  name: "Tuxedo Button",
   inputs: [
     {
-      name: 'variant',
-      type: 'enum',
-      enum: ['primary', 'secondary', 'outline', 'ghost', 'danger'],
-      defaultValue: 'primary',
+      name: "variant",
+      type: "enum",
+      enum: ["primary", "secondary", "outline", "ghost", "danger"],
+      defaultValue: "primary",
     },
     {
-      name: 'size',
-      type: 'enum',
-      enum: ['small', 'medium', 'large'],
-      defaultValue: 'medium',
+      name: "size",
+      type: "enum",
+      enum: ["small", "medium", "large"],
+      defaultValue: "medium",
     },
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Button',
+      name: "children",
+      type: "string",
+      defaultValue: "Button",
     },
     {
-      name: 'disabled',
-      type: 'boolean',
+      name: "disabled",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'loading',
-      type: 'boolean',
+      name: "loading",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'fullWidth',
-      type: 'boolean',
+      name: "fullWidth",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
     {
-      name: 'onClick',
-      type: 'action',
-      defaultValue: '() => {}',
+      name: "onClick",
+      type: "action",
+      defaultValue: "() => {}",
     },
   ],
 });
 
 Builder.registerComponent(Card, {
-  name: 'Tuxedo Card',
+  name: "Tuxedo Card",
   inputs: [
     {
-      name: 'variant',
-      type: 'enum',
-      enum: ['default', 'outlined', 'elevated'],
-      defaultValue: 'default',
+      name: "variant",
+      type: "enum",
+      enum: ["default", "outlined", "elevated"],
+      defaultValue: "default",
     },
     {
-      name: 'padding',
-      type: 'enum',
-      enum: ['none', 'small', 'medium', 'large'],
-      defaultValue: 'medium',
+      name: "padding",
+      type: "enum",
+      enum: ["none", "small", "medium", "large"],
+      defaultValue: "medium",
     },
     {
-      name: 'children',
-      type: 'uiBlocks',
+      name: "children",
+      type: "uiBlocks",
       defaultValue: [
         {
-          '@type': '@builder.io/sdk:Element',
+          "@type": "@builder.io/sdk:Element",
           component: {
-            name: 'Text',
+            name: "Text",
             options: {
-              text: 'Card Content'
-            }
-          }
-        }
+              text: "Card Content",
+            },
+          },
+        },
       ],
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
   ],
 });
 
 Builder.registerComponent(Input, {
-  name: 'Tuxedo Input',
+  name: "Tuxedo Input",
   inputs: [
     {
-      name: 'type',
-      type: 'enum',
-      enum: ['text', 'email', 'password', 'number', 'tel', 'url'],
-      defaultValue: 'text',
+      name: "type",
+      type: "enum",
+      enum: ["text", "email", "password", "number", "tel", "url"],
+      defaultValue: "text",
     },
     {
-      name: 'label',
-      type: 'string',
-      defaultValue: '',
+      name: "label",
+      type: "string",
+      defaultValue: "",
     },
     {
-      name: 'placeholder',
-      type: 'string',
-      defaultValue: 'Enter text...',
+      name: "placeholder",
+      type: "string",
+      defaultValue: "Enter text...",
     },
     {
-      name: 'error',
-      type: 'string',
-      defaultValue: '',
+      name: "error",
+      type: "string",
+      defaultValue: "",
     },
     {
-      name: 'disabled',
-      type: 'boolean',
+      name: "disabled",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'fullWidth',
-      type: 'boolean',
+      name: "fullWidth",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
     {
-      name: 'onChange',
-      type: 'action',
-      defaultValue: '() => {}',
+      name: "onChange",
+      type: "action",
+      defaultValue: "() => {}",
     },
   ],
 });
 
 Builder.registerComponent(Modal, {
-  name: 'Tuxedo Modal',
+  name: "Tuxedo Modal",
   inputs: [
     {
-      name: 'isOpen',
-      type: 'boolean',
+      name: "isOpen",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'title',
-      type: 'string',
-      defaultValue: 'Modal Title',
+      name: "title",
+      type: "string",
+      defaultValue: "Modal Title",
     },
     {
-      name: 'size',
-      type: 'enum',
-      enum: ['small', 'medium', 'large', 'fullscreen'],
-      defaultValue: 'medium',
+      name: "size",
+      type: "enum",
+      enum: ["small", "medium", "large", "fullscreen"],
+      defaultValue: "medium",
     },
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Modal Content',
+      name: "children",
+      type: "string",
+      defaultValue: "Modal Content",
     },
     {
-      name: 'onClose',
-      type: 'action',
-      defaultValue: '() => {}',
+      name: "onClose",
+      type: "action",
+      defaultValue: "() => {}",
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
+    },
+  ],
+});
+
+Builder.registerComponent(BreakdownQuoteCard, {
+  name: "Breakdown Quote Card",
+  inputs: [
+    {
+      name: "vehicleReg",
+      type: "string",
+      defaultValue: "ML18 UOE",
+      helperText: "Vehicle registration number to display in the quote title",
+    },
+    {
+      name: "title",
+      type: "string",
+      defaultValue: "",
+      helperText:
+        'Custom title - if not provided, will use "Get breakdown quotes for [vehicleReg] in seconds"',
+    },
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Choose from local, nationwide or European cover then see your prices",
+      helperText: "Description text below the title",
+    },
+    {
+      name: "buttonText",
+      type: "string",
+      defaultValue: "Get instant quotes",
+      helperText: "Text to display on the action button",
+    },
+    {
+      name: "showIcon",
+      type: "boolean",
+      defaultValue: true,
+      helperText: "Show or hide the motor breakdown icon",
+    },
+    {
+      name: "disabled",
+      type: "boolean",
+      defaultValue: false,
+      helperText: "Disable the action button",
+    },
+    {
+      name: "className",
+      type: "string",
+      defaultValue: "",
+      helperText: "Additional CSS classes",
+    },
+    {
+      name: "onButtonClick",
+      type: "action",
+      defaultValue: '() => console.log("Quote card clicked")',
+      helperText: "Action to perform when the button is clicked",
     },
   ],
 });
 
 // Register HeroSection component with dynamic inputs
 Builder.registerComponent(HeroSection, {
-  name: 'Hero Section',
+  name: "Hero Section",
   inputs: [
     {
-      name: 'badgeText',
-      type: 'string',
-      defaultValue: '✨ New Collection Available',
+      name: "badgeText",
+      type: "string",
+      defaultValue: "✨ New Collection Available",
     },
     {
-      name: 'badgeVariant',
-      type: 'enum',
-      enum: ['primary', 'secondary', 'success', 'warning', 'danger', 'info'],
-      defaultValue: 'secondary',
+      name: "badgeVariant",
+      type: "enum",
+      enum: ["primary", "secondary", "success", "warning", "danger", "info"],
+      defaultValue: "secondary",
     },
     {
-      name: 'personName',
-      type: 'string',
-      defaultValue: '',
-      helperText: 'Optional name to display above the main heading.'
+      name: "personName",
+      type: "string",
+      defaultValue: "",
+      helperText: "Optional name to display above the main heading.",
     },
     {
-      name: 'mainHeading',
-      type: 'string',
-      defaultValue: 'Compare & Save',
+      name: "mainHeading",
+      type: "string",
+      defaultValue: "Compare & Save",
     },
     {
-      name: 'gradientText',
-      type: 'string',
-      defaultValue: 'On Everything',
+      name: "gradientText",
+      type: "string",
+      defaultValue: "On Everything",
     },
     {
-      name: 'subHeading',
-      type: 'string',
-      defaultValue: 'You Need',
+      name: "subHeading",
+      type: "string",
+      defaultValue: "You Need",
     },
     {
-      name: 'subtitle',
-      type: 'string',
-      defaultValue: 'From insurance to energy, mobiles to mortgages. Find the best deals and compare prices to save money on all your essentials.',
+      name: "subtitle",
+      type: "string",
+      defaultValue:
+        "From insurance to energy, mobiles to mortgages. Find the best deals and compare prices to save money on all your essentials.",
     },
     {
-      name: 'primaryButtonText',
-      type: 'string',
-      defaultValue: 'Shop Collection',
+      name: "primaryButtonText",
+      type: "string",
+      defaultValue: "Shop Collection",
     },
     {
-      name: 'primaryButtonVariant',
-      type: 'enum',
-      enum: ['primary', 'secondary', 'outline', 'ghost', 'danger'],
-      defaultValue: 'secondary',
+      name: "primaryButtonVariant",
+      type: "enum",
+      enum: ["primary", "secondary", "outline", "ghost", "danger"],
+      defaultValue: "secondary",
     },
     {
-      name: 'primaryButtonSize',
-      type: 'enum',
-      enum: ['small', 'medium', 'large'],
-      defaultValue: 'large',
+      name: "primaryButtonSize",
+      type: "enum",
+      enum: ["small", "medium", "large"],
+      defaultValue: "large",
     },
     {
-      name: 'secondaryButtonText',
-      type: 'string',
-      defaultValue: 'Watch Story',
+      name: "secondaryButtonText",
+      type: "string",
+      defaultValue: "Watch Story",
     },
     {
-      name: 'secondaryButtonVariant',
-      type: 'enum',
-      enum: ['primary', 'secondary', 'outline', 'ghost', 'danger'],
-      defaultValue: 'outline',
+      name: "secondaryButtonVariant",
+      type: "enum",
+      enum: ["primary", "secondary", "outline", "ghost", "danger"],
+      defaultValue: "outline",
     },
     {
-      name: 'secondaryButtonSize',
-      type: 'enum',
-      enum: ['small', 'medium', 'large'],
-      defaultValue: 'large',
+      name: "secondaryButtonSize",
+      type: "enum",
+      enum: ["small", "medium", "large"],
+      defaultValue: "large",
     },
     {
-      name: 'showStats',
-      type: 'boolean',
+      name: "showStats",
+      type: "boolean",
       defaultValue: true,
     },
     {
-      name: 'stat1Value',
-      type: 'string',
-      defaultValue: '50K+',
+      name: "stat1Value",
+      type: "string",
+      defaultValue: "50K+",
     },
     {
-      name: 'stat1Label',
-      type: 'string',
-      defaultValue: 'Happy Customers',
+      name: "stat1Label",
+      type: "string",
+      defaultValue: "Happy Customers",
     },
     {
-      name: 'stat2Value',
-      type: 'string',
-      defaultValue: '1000+',
+      name: "stat2Value",
+      type: "string",
+      defaultValue: "1000+",
     },
     {
-      name: 'stat2Label',
-      type: 'string',
-      defaultValue: 'Premium Products',
+      name: "stat2Label",
+      type: "string",
+      defaultValue: "Premium Products",
     },
     {
-      name: 'stat3Value',
-      type: 'string',
-      defaultValue: '98%',
+      name: "stat3Value",
+      type: "string",
+      defaultValue: "98%",
     },
     {
-      name: 'stat3Label',
-      type: 'string',
-      defaultValue: 'Satisfaction Rate',
+      name: "stat3Label",
+      type: "string",
+      defaultValue: "Satisfaction Rate",
     },
     {
-      name: 'showScrollIndicator',
-      type: 'boolean',
+      name: "showScrollIndicator",
+      type: "boolean",
       defaultValue: true,
     },
     {
-      name: 'backgroundGradient',
-      type: 'boolean',
+      name: "backgroundGradient",
+      type: "boolean",
       defaultValue: true,
     },
     {
-      name: 'animatedBackground',
-      type: 'boolean',
+      name: "animatedBackground",
+      type: "boolean",
       defaultValue: true,
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
     {
-      name: 'onPrimaryButtonClick',
-      type: 'action',
-      defaultValue: '() => {}',
+      name: "onPrimaryButtonClick",
+      type: "action",
+      defaultValue: "() => {}",
     },
     {
-      name: 'onSecondaryButtonClick',
-      type: 'action',
-      defaultValue: '() => {}',
+      name: "onSecondaryButtonClick",
+      type: "action",
+      defaultValue: "() => {}",
     },
     {
-      name: 'statLabelsLight',
-      type: 'boolean',
+      name: "statLabelsLight",
+      type: "boolean",
       defaultValue: true,
-      helperText: 'Use light font color for stat labels (for dark backgrounds)',
+      helperText: "Use light font color for stat labels (for dark backgrounds)",
     },
   ],
 });
 
 // Register NewsLetterCTA component with dynamic inputs
 Builder.registerComponent(NewsLetterCTA, {
-  name: 'Newsletter CTA',
+  name: "Newsletter CTA",
   inputs: [
     {
-      name: 'title',
-      type: 'string',
-      defaultValue: 'Stay Updated',
+      name: "title",
+      type: "string",
+      defaultValue: "Stay Updated",
     },
     {
-      name: 'description',
-      type: 'string',
-      defaultValue: 'Get the latest deals, comparison guides, and money-saving tips delivered straight to your inbox.',
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Get the latest deals, comparison guides, and money-saving tips delivered straight to your inbox.",
     },
     {
-      name: 'placeholder',
-      type: 'string',
-      defaultValue: 'Enter your email',
+      name: "placeholder",
+      type: "string",
+      defaultValue: "Enter your email",
     },
     {
-      name: 'buttonText',
-      type: 'string',
-      defaultValue: 'Subscribe',
+      name: "buttonText",
+      type: "string",
+      defaultValue: "Subscribe",
     },
     {
-      name: 'buttonVariant',
-      type: 'enum',
-      enum: ['primary', 'secondary', 'outline', 'ghost', 'danger'],
-      defaultValue: 'primary',
+      name: "buttonVariant",
+      type: "enum",
+      enum: ["primary", "secondary", "outline", "ghost", "danger"],
+      defaultValue: "primary",
     },
     {
-      name: 'disclaimer',
-      type: 'string',
-      defaultValue: 'Join millions of savvy shoppers. Unsubscribe anytime.',
+      name: "disclaimer",
+      type: "string",
+      defaultValue: "Join millions of savvy shoppers. Unsubscribe anytime.",
     },
     {
-      name: 'backgroundGradient',
-      type: 'boolean',
+      name: "backgroundGradient",
+      type: "boolean",
       defaultValue: true,
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
     {
-      name: 'onSubmit',
-      type: 'action',
+      name: "onSubmit",
+      type: "action",
       defaultValue: '(email) => console.log("Newsletter subscription:", email)',
     },
   ],
@@ -420,7 +479,8 @@ Builder.registerComponent(FeatureCard, {
     {
       name: "image",
       type: "string",
-      defaultValue: "https://cdn.builder.io/api/v1/image/assets%2Fexample-icon.png",
+      defaultValue:
+        "https://cdn.builder.io/api/v1/image/assets%2Fexample-icon.png",
       helperText: "Image URL or icon URL",
     },
     {
@@ -441,23 +501,23 @@ Builder.registerComponent(FeaturesSection, {
   name: "Features Section",
   inputs: [
     {
-      name: 'children',
-      type: 'uiBlocks',
+      name: "children",
+      type: "uiBlocks",
       defaultValue: [
         {
-          '@type': '@builder.io/sdk:Element',
+          "@type": "@builder.io/sdk:Element",
           component: {
-            name: 'Text',
+            name: "Text",
             options: {
-              text: 'Feature Card Content'
-            }
-          }
-        }
+              text: "Feature Card Content",
+            },
+          },
+        },
       ],
     },
   ],
 });
 
 Builder.registerComponent(WelcomeBanner, {
-  name: 'Welcome Banner'
-}); 
+  name: "Welcome Banner",
+});

--- a/src/components/tuxedo/BreakdownQuoteCard.tsx
+++ b/src/components/tuxedo/BreakdownQuoteCard.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/tuxedo";
+
+export interface TuxedoBreakdownQuoteCardProps {
+  vehicleReg?: string;
+  title?: string;
+  description?: string;
+  buttonText?: string;
+  showIcon?: boolean;
+  disabled?: boolean;
+  onButtonClick?: () => void;
+  className?: string;
+  testId?: string;
+}
+
+const MotorBreakdownIcon = () => (
+  <svg
+    width="29"
+    height="28"
+    viewBox="0 0 29 28"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-7 h-7"
+  >
+    <path
+      d="M17.8999 6.20007L15.1001 11.1001L22.8999 24.8H28.6001L17.8999 6.20007Z"
+      fill="white"
+    />
+    <path
+      d="M17.2002 5L14.3999 0H14.2998L3.6001 18.6001H9.3999L17.2002 5Z"
+      fill="white"
+    />
+    <path
+      d="M2.8999 19.8L0.100098 24.7001L0 24.8H21.5L18.6001 19.8H2.8999Z"
+      fill="white"
+    />
+  </svg>
+);
+
+const ArrowIcon = () => (
+  <svg
+    width="18"
+    height="19"
+    viewBox="0 0 18 19"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-4 h-4 ml-2"
+  >
+    <path
+      d="M9 0L6.75 2.32503L11.85 7.42502H0V10.65H11.85L6.75 15.75L9 18.075L17.925 9.07503L9 0Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const BreakdownQuoteCard = React.forwardRef<
+  HTMLDivElement,
+  TuxedoBreakdownQuoteCardProps
+>(
+  (
+    {
+      vehicleReg = "ML18 UOE",
+      title,
+      description = "Choose from local, nationwide or European cover then see your prices",
+      buttonText = "Get instant quotes",
+      showIcon = true,
+      disabled = false,
+      onButtonClick,
+      className,
+      testId,
+      ...props
+    },
+    ref,
+  ) => {
+    const displayTitle =
+      title || `Get breakdown quotes for ${vehicleReg} in seconds`;
+
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        className={cn(
+          "flex flex-col w-full max-w-sm mx-auto bg-white rounded-lg overflow-hidden shadow-lg",
+          className,
+        )}
+        {...props}
+      >
+        {/* Header with blue background */}
+        <div
+          className="flex flex-col p-6 gap-4"
+          style={{ backgroundColor: "#58AAE0" }}
+        >
+          {/* Icon and Title */}
+          <div className="flex items-start gap-4">
+            {showIcon && (
+              <div className="flex items-center justify-center w-11 h-11 rounded-full bg-black p-2 flex-shrink-0">
+                <MotorBreakdownIcon />
+              </div>
+            )}
+            <h2
+              className="text-xl md:text-[22px] font-bold leading-7 text-black flex-1"
+              style={{
+                fontFamily:
+                  "Poppins, -apple-system, Roboto, Helvetica, sans-serif",
+              }}
+            >
+              {displayTitle}
+            </h2>
+          </div>
+
+          {/* Description */}
+          <p
+            className="text-lg text-black leading-[26px]"
+            style={{
+              fontFamily:
+                "Poppins, -apple-system, Roboto, Helvetica, sans-serif",
+            }}
+          >
+            {description}
+          </p>
+
+          {/* Button */}
+          <button
+            onClick={onButtonClick}
+            disabled={disabled}
+            className={cn(
+              "flex items-center justify-center w-60 h-16 px-6 py-4 rounded-xl bg-black text-white font-bold text-lg leading-[26px] transition-all duration-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed",
+              "max-w-full",
+            )}
+            style={{
+              fontFamily:
+                "Poppins, -apple-system, Roboto, Helvetica, sans-serif",
+            }}
+          >
+            <span>{buttonText}</span>
+            <ArrowIcon />
+          </button>
+        </div>
+      </div>
+    );
+  },
+);
+
+BreakdownQuoteCard.displayName = "TuxedoBreakdownQuoteCard";
+
+export default BreakdownQuoteCard;

--- a/src/components/tuxedo/index.ts
+++ b/src/components/tuxedo/index.ts
@@ -16,9 +16,13 @@ export type { TuxedoBadgeProps } from "./Badge";
 export { default as Modal } from "./Modal";
 export type { TuxedoModalProps } from "./Modal";
 
+export { default as BreakdownQuoteCard } from "./BreakdownQuoteCard";
+export type { TuxedoBreakdownQuoteCardProps } from "./BreakdownQuoteCard";
+
 // Re-export all components for convenience
 export * from "./Button";
 export * from "./Input";
 export * from "./Card";
 export * from "./Badge";
 export * from "./Modal";
+export * from "./BreakdownQuoteCard";

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap");
 
 @tailwind base;
 @tailwind components;

--- a/src/pages/TuxedoShowcase.tsx
+++ b/src/pages/TuxedoShowcase.tsx
@@ -2,7 +2,14 @@ import { useState } from "react";
 import { Search, ShoppingCart, Heart } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import { Button, Input, Card, Badge, Modal } from "@/components/tuxedo";
+import {
+  Button,
+  Input,
+  Card,
+  Badge,
+  Modal,
+  BreakdownQuoteCard,
+} from "@/components/tuxedo";
 
 const TuxedoShowcase = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -208,6 +215,102 @@ const TuxedoShowcase = () => {
             </div>
           </div>
 
+          {/* Breakdown Quote Cards Section */}
+          <Card variant="outlined" padding="large">
+            <h2 className="text-2xl font-bold text-white mb-6">
+              Breakdown Quote Cards
+            </h2>
+            <div className="space-y-8">
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Default Configuration
+                </h3>
+                <div className="flex justify-center">
+                  <BreakdownQuoteCard
+                    onButtonClick={() => console.log("Default card clicked")}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Custom Vehicle Registration
+                </h3>
+                <div className="flex justify-center">
+                  <BreakdownQuoteCard
+                    vehicleReg="AB12 CDE"
+                    onButtonClick={() => console.log("Custom reg card clicked")}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Custom Content
+                </h3>
+                <div className="flex justify-center">
+                  <BreakdownQuoteCard
+                    title="Motor breakdown insurance quotes in seconds"
+                    description="Get comprehensive coverage with 24/7 roadside assistance and recovery services"
+                    buttonText="Compare prices now"
+                    onButtonClick={() =>
+                      console.log("Custom content card clicked")
+                    }
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Without Icon
+                </h3>
+                <div className="flex justify-center">
+                  <BreakdownQuoteCard
+                    vehicleReg="XY21 ZXY"
+                    showIcon={false}
+                    onButtonClick={() => console.log("No icon card clicked")}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Disabled State
+                </h3>
+                <div className="flex justify-center">
+                  <BreakdownQuoteCard
+                    vehicleReg="DIS 123"
+                    buttonText="Service unavailable"
+                    disabled={true}
+                    onButtonClick={() =>
+                      console.log("This shouldn't be called")
+                    }
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Grid Layout Example
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center">
+                  <BreakdownQuoteCard
+                    vehicleReg="GR1 123"
+                    onButtonClick={() => console.log("Grid card 1 clicked")}
+                  />
+                  <BreakdownQuoteCard
+                    vehicleReg="GR2 456"
+                    onButtonClick={() => console.log("Grid card 2 clicked")}
+                  />
+                  <BreakdownQuoteCard
+                    vehicleReg="GR3 789"
+                    onButtonClick={() => console.log("Grid card 3 clicked")}
+                  />
+                </div>
+              </div>
+            </div>
+          </Card>
+
           {/* Modal Section */}
           <Card variant="outlined" padding="large">
             <h2 className="text-2xl font-bold text-white mb-6">Modal</h2>
@@ -281,6 +384,13 @@ const TuxedoShowcase = () => {
                 <li>
                   <strong className="text-brand-amber">Modal</strong> - Dialog
                   and overlay components
+                </li>
+                <li>
+                  <strong className="text-brand-amber">
+                    BreakdownQuoteCard
+                  </strong>{" "}
+                  - Interactive quote cards with motor breakdown icon and
+                  customizable content
                 </li>
               </ul>
               <p>


### PR DESCRIPTION
This pull request adds a new BreakdownQuoteCard component to the Tuxedo design system and updates string quotes throughout the codebase.

Changes made:
- Added new BreakdownQuoteCard component with motor breakdown icon and arrow icon
- Registered BreakdownQuoteCard with Builder.io with configurable inputs for vehicle registration, title, description, button text, and styling options
- Updated all single quotes to double quotes in builder-registry.ts for consistency
- Added BreakdownQuoteCard export to tuxedo components index
- Added Poppins font import to index.css
- Added comprehensive showcase examples for BreakdownQuoteCard in TuxedoShowcase page including default, custom content, disabled state, and grid layout variations

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c89c5069cb640248b320a9da0edae1e/glow-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c89c5069cb640248b320a9da0edae1e</projectId>-->
<!--<branchName>glow-field</branchName>-->