### PR TITLE
Add MotorBreakdownQuoteCard component to Tuxedo

### DIFF
--- a/src/components/tuxedo/MotorBreakdownQuoteCard.tsx
+++ b/src/components/tuxedo/MotorBreakdownQuoteCard.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TuxedoMotorBreakdownQuoteCardProps {
+  vehicleReg?: string;
+  title?: string;
+  description?: string;
+  buttonText?: string;
+  showIcon?: boolean;
+  disabled?: boolean;
+  onButtonClick?: () => void;
+  className?: string;
+  testId?: string;
+}
+
+const MotorBreakdownQuoteCard = React.forwardRef<
+  HTMLDivElement,
+  TuxedoMotorBreakdownQuoteCardProps
+>(
+  (
+    {
+      vehicleReg = "ML18 UOE",
+      title,
+      description = "Choose from local, nationwide or European cover then see your prices",
+      buttonText = "Get instant quotes",
+      showIcon = true,
+      disabled = false,
+      onButtonClick,
+      className,
+      testId,
+      ...props
+    },
+    ref,
+  ) => {
+    const displayTitle =
+      title || `Get breakdown quotes for ${vehicleReg} in seconds`;
+
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        className={cn("flex flex-col w-full max-w-sm", className)}
+        {...props}
+      >
+        {/* Quote Card */}
+        <div className="flex flex-col bg-white rounded-lg overflow-hidden shadow-lg">
+          {/* Header */}
+          <div className="flex flex-col gap-4 p-6 bg-brand-car-blue">
+            {/* Icon & Title Row */}
+            <div className="flex items-start gap-4">
+              {showIcon && (
+                <div className="flex items-center justify-center w-[43px] h-[43px] rounded-full bg-brand-primary-dark flex-shrink-0">
+                  <svg
+                    width="29"
+                    height="25"
+                    viewBox="0 0 29 28"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-[29px] h-[25px]"
+                  >
+                    <path
+                      d="M17.8999 6.20007L15.1001 11.1001L22.8999 24.8H28.6001L17.8999 6.20007Z"
+                      fill="white"
+                    />
+                    <path
+                      d="M17.2002 5L14.3999 0H14.2998L3.6001 18.6001H9.3999L17.2002 5Z"
+                      fill="white"
+                    />
+                    <path
+                      d="M2.8999 19.8L0.100098 24.7001L0 24.8H21.5L18.6001 19.8H2.8999Z"
+                      fill="white"
+                    />
+                  </svg>
+                </div>
+              )}
+
+              {/* Title */}
+              <h2 className="flex-1 text-brand-primary-dark text-xl md:text-[22px] font-bold leading-tight font-['Poppins',_'Inter',_-apple-system,_'Roboto',_'Helvetica',_sans-serif]">
+                {displayTitle}
+              </h2>
+            </div>
+
+            {/* Description */}
+            <p className="text-brand-primary-dark text-lg leading-relaxed font-['Poppins',_'Inter',_-apple-system,_'Roboto',_'Helvetica',_sans-serif]">
+              {description}
+            </p>
+
+            {/* Button */}
+            <button
+              onClick={onButtonClick}
+              disabled={disabled}
+              className={cn(
+                "flex items-center justify-center gap-2 w-full max-w-[240px] h-16 px-6 py-4 rounded-xl bg-brand-primary-dark text-white text-lg font-bold transition-all duration-200 font-['Poppins',_'Inter',_-apple-system,_'Roboto',_'Helvetica',_sans-serif]",
+                "hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 focus:ring-offset-brand-car-blue",
+                {
+                  "opacity-50 cursor-not-allowed": disabled,
+                  "active:scale-95": !disabled,
+                },
+              )}
+            >
+              <span className="flex-1 text-left">{buttonText}</span>
+              <div className="flex items-center justify-center w-8 h-8 flex-shrink-0">
+                <svg
+                  width="18"
+                  height="19"
+                  viewBox="0 0 18 19"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-[18px] h-[18px]"
+                >
+                  <path
+                    d="M9 0L6.75 2.32503L11.85 7.42502H0V10.65H11.85L6.75 15.75L9 18.075L17.925 9.07503L9 0Z"
+                    fill="white"
+                  />
+                </svg>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+MotorBreakdownQuoteCard.displayName = "TuxedoMotorBreakdownQuoteCard";
+
+export default MotorBreakdownQuoteCard;

--- a/src/components/tuxedo/index.ts
+++ b/src/components/tuxedo/index.ts
@@ -16,9 +16,13 @@ export type { TuxedoBadgeProps } from "./Badge";
 export { default as Modal } from "./Modal";
 export type { TuxedoModalProps } from "./Modal";
 
+export { default as MotorBreakdownQuoteCard } from "./MotorBreakdownQuoteCard";
+export type { TuxedoMotorBreakdownQuoteCardProps } from "./MotorBreakdownQuoteCard";
+
 // Re-export all components for convenience
 export * from "./Button";
 export * from "./Input";
 export * from "./Card";
 export * from "./Badge";
 export * from "./Modal";
+export * from "./MotorBreakdownQuoteCard";

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap");
 
 @tailwind base;
 @tailwind components;

--- a/src/lib/builder-registry.ts
+++ b/src/lib/builder-registry.ts
@@ -122,3 +122,47 @@ Builder.registerComponent(Modal, {
     },
   ],
 });
+
+Builder.registerComponent(MotorBreakdownQuoteCard, {
+  name: "Tuxedo Motor Breakdown Quote Card",
+  inputs: [
+    {
+      name: "vehicleReg",
+      type: "string",
+      defaultValue: "ML18 UOE",
+      helperText: "Vehicle registration number to display in the title",
+    },
+    {
+      name: "title",
+      type: "string",
+      defaultValue: "",
+      helperText:
+        "Custom title (if empty, will use vehicle reg in default format)",
+    },
+    {
+      name: "description",
+      type: "string",
+      defaultValue:
+        "Choose from local, nationwide or European cover then see your prices",
+      helperText: "Description text below the title",
+    },
+    {
+      name: "buttonText",
+      type: "string",
+      defaultValue: "Get instant quotes",
+      helperText: "Text to display on the action button",
+    },
+    {
+      name: "showIcon",
+      type: "boolean",
+      defaultValue: true,
+      helperText: "Whether to show the motor breakdown icon",
+    },
+    {
+      name: "disabled",
+      type: "boolean",
+      defaultValue: false,
+      helperText: "Whether the button should be disabled",
+    },
+  ],
+});

--- a/src/lib/builder-registry.ts
+++ b/src/lib/builder-registry.ts
@@ -1,123 +1,124 @@
-import { Builder } from '@builder.io/react';
+import { Builder } from "@builder.io/react";
 import {
   Badge,
   Button,
   Card,
   Input,
   Modal,
-} from '../components/tuxedo';
+  MotorBreakdownQuoteCard,
+} from "../components/tuxedo";
 
 // Register all Tuxedo components with Builder.io
 Builder.registerComponent(Badge, {
-  name: 'Tuxedo Badge',
+  name: "Tuxedo Badge",
   inputs: [
     {
-      name: 'variant',
-      type: 'enum',
-      enum: ['default', 'secondary', 'destructive', 'outline'],
-      defaultValue: 'default',
+      name: "variant",
+      type: "enum",
+      enum: ["default", "secondary", "destructive", "outline"],
+      defaultValue: "default",
     },
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Badge',
+      name: "children",
+      type: "string",
+      defaultValue: "Badge",
     },
   ],
 });
 
 Builder.registerComponent(Button, {
-  name: 'Tuxedo Button',
+  name: "Tuxedo Button",
   inputs: [
     {
-      name: 'variant',
-      type: 'enum',
-      enum: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
-      defaultValue: 'default',
+      name: "variant",
+      type: "enum",
+      enum: ["default", "destructive", "outline", "secondary", "ghost", "link"],
+      defaultValue: "default",
     },
     {
-      name: 'size',
-      type: 'enum',
-      enum: ['default', 'sm', 'lg', 'icon'],
-      defaultValue: 'default',
+      name: "size",
+      type: "enum",
+      enum: ["default", "sm", "lg", "icon"],
+      defaultValue: "default",
     },
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Button',
+      name: "children",
+      type: "string",
+      defaultValue: "Button",
     },
     {
-      name: 'disabled',
-      type: 'boolean',
+      name: "disabled",
+      type: "boolean",
       defaultValue: false,
     },
   ],
 });
 
 Builder.registerComponent(Card, {
-  name: 'Tuxedo Card',
+  name: "Tuxedo Card",
   inputs: [
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Card Content',
+      name: "children",
+      type: "string",
+      defaultValue: "Card Content",
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
   ],
 });
 
 Builder.registerComponent(Input, {
-  name: 'Tuxedo Input',
+  name: "Tuxedo Input",
   inputs: [
     {
-      name: 'type',
-      type: 'enum',
-      enum: ['text', 'email', 'password', 'number', 'tel', 'url'],
-      defaultValue: 'text',
+      name: "type",
+      type: "enum",
+      enum: ["text", "email", "password", "number", "tel", "url"],
+      defaultValue: "text",
     },
     {
-      name: 'placeholder',
-      type: 'string',
-      defaultValue: 'Enter text...',
+      name: "placeholder",
+      type: "string",
+      defaultValue: "Enter text...",
     },
     {
-      name: 'disabled',
-      type: 'boolean',
+      name: "disabled",
+      type: "boolean",
       defaultValue: false,
     },
     {
-      name: 'className',
-      type: 'string',
-      defaultValue: '',
+      name: "className",
+      type: "string",
+      defaultValue: "",
     },
   ],
 });
 
 Builder.registerComponent(Modal, {
-  name: 'Tuxedo Modal',
+  name: "Tuxedo Modal",
   inputs: [
     {
-      name: 'title',
-      type: 'string',
-      defaultValue: 'Modal Title',
+      name: "title",
+      type: "string",
+      defaultValue: "Modal Title",
     },
     {
-      name: 'description',
-      type: 'string',
-      defaultValue: 'Modal description',
+      name: "description",
+      type: "string",
+      defaultValue: "Modal description",
     },
     {
-      name: 'children',
-      type: 'string',
-      defaultValue: 'Modal Content',
+      name: "children",
+      type: "string",
+      defaultValue: "Modal Content",
     },
     {
-      name: 'isOpen',
-      type: 'boolean',
+      name: "isOpen",
+      type: "boolean",
       defaultValue: false,
     },
   ],
-}); 
+});

--- a/src/pages/TuxedoShowcase.tsx
+++ b/src/pages/TuxedoShowcase.tsx
@@ -2,7 +2,14 @@ import { useState } from "react";
 import { Search, ShoppingCart, Heart } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import { Button, Input, Card, Badge, Modal } from "@/components/tuxedo";
+import {
+  Button,
+  Input,
+  Card,
+  Badge,
+  Modal,
+  MotorBreakdownQuoteCard,
+} from "@/components/tuxedo";
 
 const TuxedoShowcase = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/pages/TuxedoShowcase.tsx
+++ b/src/pages/TuxedoShowcase.tsx
@@ -355,6 +355,13 @@ const TuxedoShowcase = () => {
                   <strong className="text-brand-amber">Modal</strong> - Dialog
                   and overlay components
                 </li>
+                <li>
+                  <strong className="text-brand-amber">
+                    MotorBreakdownQuoteCard
+                  </strong>{" "}
+                  - Insurance quote card with vehicle registration and breakdown
+                  coverage options
+                </li>
               </ul>
               <p>
                 All components follow the exact design specifications from the

--- a/src/pages/TuxedoShowcase.tsx
+++ b/src/pages/TuxedoShowcase.tsx
@@ -257,6 +257,72 @@ const TuxedoShowcase = () => {
             </div>
           </Modal>
 
+          {/* Motor Breakdown Quote Card Section */}
+          <Card variant="outlined" padding="large">
+            <h2 className="text-2xl font-bold text-white mb-6">
+              Motor Breakdown Quote Card
+            </h2>
+            <div className="space-y-6">
+              <p className="text-brand-gray-light">
+                Motor breakdown quote card component that matches the Figma
+                design with responsive layout and interactive elements.
+              </p>
+
+              {/* Default Example */}
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Default
+                </h3>
+                <div className="flex justify-start">
+                  <MotorBreakdownQuoteCard />
+                </div>
+              </div>
+
+              {/* Custom Examples */}
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Custom Examples
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  <MotorBreakdownQuoteCard
+                    vehicleReg="AB12 CDE"
+                    buttonText="Compare Quotes"
+                    onButtonClick={() => alert("Custom button clicked!")}
+                  />
+                  <MotorBreakdownQuoteCard
+                    vehicleReg="XY99 ZAB"
+                    title="Get breakdown quotes for XY99 ZAB today"
+                    description="Comprehensive coverage options available with instant pricing"
+                    buttonText="View Options"
+                    showIcon={false}
+                  />
+                  <MotorBreakdownQuoteCard
+                    vehicleReg="TEST 123"
+                    buttonText="Get Quote"
+                    disabled={true}
+                  />
+                </div>
+              </div>
+
+              {/* Features */}
+              <div>
+                <h3 className="text-lg font-semibold text-brand-amber mb-4">
+                  Features
+                </h3>
+                <ul className="list-disc list-inside space-y-2 text-brand-gray-light">
+                  <li>Responsive design that works on all screen sizes</li>
+                  <li>Dynamic vehicle registration replacement in title</li>
+                  <li>Customizable button text and actions</li>
+                  <li>Optional motor breakdown icon display</li>
+                  <li>Disabled state support</li>
+                  <li>Poppins font family for brand consistency</li>
+                  <li>Hover and focus states for accessibility</li>
+                  <li>Perfect pixel match to Figma design</li>
+                </ul>
+              </div>
+            </div>
+          </Card>
+
           {/* Summary */}
           <Card variant="outlined" padding="large">
             <h2 className="text-2xl font-bold text-white mb-6">


### PR DESCRIPTION
This pull request adds a new MotorBreakdownQuoteCard component to the Tuxedo design system.

Changes made:
- Created new MotorBreakdownQuoteCard.tsx component with TypeScript interface
- Added component exports to tuxedo/index.ts
- Imported Poppins font family in index.css
- Registered component with Builder.io in builder-registry.ts
- Added component showcase examples in TuxedoShowcase.tsx

The component features:
- Responsive design with customizable vehicle registration
- Optional motor breakdown icon display
- Configurable button text and click handlers
- Disabled state support
- Brand-consistent styling with Poppins font
- Accessibility features including hover and focus states

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c89c5069cb640248b320a9da0edae1e/aura-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c89c5069cb640248b320a9da0edae1e</projectId>-->
<!--<branchName>aura-field</branchName>-->